### PR TITLE
[Backport] Fix High Resolution touchpad scrolling in XWayland

### DIFF
--- a/chromium/ui/events/devices/x11/device_data_manager_x11.cc
+++ b/chromium/ui/events/devices/x11/device_data_manager_x11.cc
@@ -781,16 +781,6 @@ void DeviceDataManagerX11::UpdateScrollClassDevice(
 
   DCHECK(deviceid >= 0 && deviceid < kMaxDeviceNum);
   ScrollInfo& info = scroll_data_[deviceid];
-
-  bool legacy_scroll_available =
-      (scroll_class_info->flags & XIScrollFlagNoEmulation) == 0;
-  // If the device's highest resolution is lower than the resolution of xinput1
-  // then use xinput1's events instead (ie. don't configure smooth scrolling).
-  if (legacy_scroll_available &&
-      std::abs(scroll_class_info->increment) <= 1.0) {
-    return;
-  }
-
   switch (scroll_class_info->scroll_type) {
     case XIScrollTypeVertical:
       info.vertical.number = scroll_class_info->number;


### PR DESCRIPTION
This reversion is in upstream as per https://chromium.googlesource.com/chromium/src.git/+/48632c246b958ebde3f144fad428f3a38f3ea70f%5E%21/#F0

Please see discussion here:
https://crbug.com/712737
https://www.reddit.com/r/linux/comments/geq19d/upstream_chromium_is_finally_fixing_pixelprecise/ 
https://bugs.launchpad.net/ubuntu/+source/chromium-browser/+bug/1811219